### PR TITLE
Remove code duplication and unnecessary methods

### DIFF
--- a/Saper/Models/DifficultyState/BeginnerState.cs
+++ b/Saper/Models/DifficultyState/BeginnerState.cs
@@ -9,16 +9,21 @@ namespace Saper.Models.DifficultyState
 {
     public class BeginnerState : IDifficultyState
     {
-        private readonly GameManager _game;
-
-        public BeginnerState(GameManager game)
+        public BeginnerState(GameManager game) : base(game)
         {
-            _game = game;
+            scorePerCellDictionary = new Dictionary<CellType, int>()
+            {
+                {CellType.Zero, 0 }, {CellType.One, 15},
+                {CellType.Two, 15 }, {CellType.Three, 15},
+                {CellType.Four, 15 }, {CellType.Five, 25},
+                {CellType.Six, 25}, {CellType.Seven, 35},
+                {CellType.Eight, 35 }
+            };
         }
 
         private const int MIN_MINES = 3;
 
-        public void GenerateMinefield()
+        public override void GenerateMinefield()
         {
             int rows = _game.Rows;
             int cols = _game.Columns;
@@ -28,20 +33,7 @@ namespace Saper.Models.DifficultyState
             _game.Minefield.InitializeField(rows, cols, mines);
         }
 
-        public void UpdateScore(CellType cellType)
-        {
-            int score = cellType switch
-            {
-                CellType.Zero => 0,
-                CellType.Five or CellType.Six => 25,
-                CellType.Seven or CellType.Eight => 35,
-                _ => 15
-            };
-
-            _game.Score += score;
-        }
-
-        public void SetHints()
+        public override void SetHints()
         {
             _game.SafeClick = 5;
         }

--- a/Saper/Models/DifficultyState/HardState.cs
+++ b/Saper/Models/DifficultyState/HardState.cs
@@ -8,39 +8,31 @@ namespace Saper.Models.DifficultyState
 {
     public class HardState : IDifficultyState
     {
-        private readonly GameManager _game;
-
         private const int MIN_MINES = 15;
 
-        public HardState(GameManager game)
+        public HardState(GameManager game) : base(game)
         {
-            _game = game;
+            scorePerCellDictionary = new Dictionary<CellType, int>()
+            {
+                {CellType.Zero, 0 }, {CellType.One, 10},
+                {CellType.Two, 10 }, {CellType.Three, 10},
+                {CellType.Four, 10 }, {CellType.Five, 15},
+                {CellType.Six, 15}, {CellType.Seven, 25},
+                {CellType.Eight, 25 }
+            };
         }
 
-        public void GenerateMinefield()
+        public override void GenerateMinefield()
         {
             int rows = _game.Rows;
             int cols = _game.Columns;
             int percent = rows * cols / 4;
-            int mines = Math.Max(MIN_MINES, percent); 
+            int mines = Math.Max(MIN_MINES, percent);
 
             _game.Minefield.InitializeField(rows, cols, mines);
         }
 
-        public void UpdateScore(CellType cellType)
-        {
-            int score = cellType switch
-            {
-                CellType.Zero => 0,
-                CellType.Five or CellType.Six => 15,
-                CellType.Seven or CellType.Eight => 25,
-                _ => 10
-            };
-
-            _game.Score += score;
-        }
-
-        public void SetHints()
+        public override void SetHints()
         {
             _game.SafeClick = 0;
         }

--- a/Saper/Models/DifficultyState/IDifficultyState.cs
+++ b/Saper/Models/DifficultyState/IDifficultyState.cs
@@ -6,10 +6,21 @@ using System.Threading.Tasks;
 
 namespace Saper.Models.DifficultyState
 {
-    public interface IDifficultyState
+    public abstract class IDifficultyState
     {
-        void GenerateMinefield();
-        void UpdateScore(CellType cellType);
-        void SetHints();
+        public IDifficultyState(GameManager game)
+        {
+            _game = game;
+        }
+
+        protected Dictionary<CellType, int> scorePerCellDictionary = new Dictionary<CellType, int>();
+        protected readonly GameManager _game;
+
+        public abstract void GenerateMinefield();
+        public virtual void UpdateScore(CellType cellType)
+        {
+            _game.Score += scorePerCellDictionary[cellType];
+        }
+        public abstract void SetHints();
     }
 }

--- a/Saper/Models/DifficultyState/IntermediateState.cs
+++ b/Saper/Models/DifficultyState/IntermediateState.cs
@@ -8,16 +8,21 @@ namespace Saper.Models.DifficultyState
 {
     public class IntermediateState : IDifficultyState
     {
-        private readonly GameManager _game;
-
         private const int MIN_MINES = 8;
 
-        public IntermediateState(GameManager game)
+        public IntermediateState(GameManager game) : base(game) 
         {
-            _game = game;
+            scorePerCellDictionary = new Dictionary<CellType, int>()
+            {
+                {CellType.Zero, 0 }, {CellType.One, 12},
+                {CellType.Two, 12 }, {CellType.Three, 12},
+                {CellType.Four, 12 }, {CellType.Five, 20},
+                {CellType.Six, 20}, {CellType.Seven, 30},
+                {CellType.Eight, 30 }
+            };
         }
 
-        public void GenerateMinefield()
+        public override void GenerateMinefield()
         {
             int rows = _game.Rows;
             int cols = _game.Columns;
@@ -27,20 +32,7 @@ namespace Saper.Models.DifficultyState
             _game.Minefield.InitializeField(rows, cols, mines);
         }
 
-        public void UpdateScore(CellType cellType)
-        {
-            int score = cellType switch
-            {
-                CellType.Zero => 0,
-                CellType.Five or CellType.Six => 20,
-                CellType.Seven or CellType.Eight => 30,
-                _ => 12
-            };
-
-            _game.Score += score;
-        }
-
-        public void SetHints()
+        public override void SetHints()
         {
             _game.SafeClick = 2;
         }

--- a/Saper/Models/GameManager.cs
+++ b/Saper/Models/GameManager.cs
@@ -55,11 +55,6 @@ namespace Saper.Models
         {
             if (!IsInsideBounds(x, y)) return;
 
-            if (IsFirstMove(x, y))
-            {
-                RegenerateFieldUntilSafeCell(x, y);
-            }
-
             Cell cell = Minefield.Cells[x, y];
 
             if (cell.IsOpend) return;
@@ -74,9 +69,6 @@ namespace Saper.Models
                 }
                 else
                 {
-                    IsEnd = true;
-                    IsWin = false;  
-                    Stopwatch.Stop();
                     EndGame(false);
                     return;  
                 }
@@ -94,25 +86,10 @@ namespace Saper.Models
 
             if (Minefield.CellsToOpen == 0)
             {
-                IsEnd = true;
-                IsWin = true;
-                Stopwatch.Stop();
                 EndGame(true);
                 return;
             }
             IsSafeClick = false;
-        }
-
-
-        private bool IsFirstMove(int x, int y) =>
-            Minefield.CellsToOpen == Rows * Columns - Minefield.MineCount;
-
-        private void RegenerateFieldUntilSafeCell(int x, int y)
-        {
-            while (Minefield.Cells[x, y].CellType != CellType.Zero)
-            {
-                DifficultyState.GenerateMinefield();
-            }
         }
 
         private void OpenSurroundingCells(int x, int y)


### PR DESCRIPTION
This PR remove code duplication from DifficultyState and delete unnecessary methods from GameManager class.

#### Changes
* I removed UpdateScore method from BeginnerState, IntermediateState and HardState and moved them into parent class(IDifficultyState) and change switch statement to Dictionary.
* I delete methods IsFirstMove and RegenerateFieldUntilSafeCell from GameManager class because game generates field with some open cells, so these methods never be called.

#### Benefits
* Reducing unnecessary code, simplify adding new classes, and you can write custom method logic, if needed, via override
* Reduce class size, make it easier to maintain and follow the YAGNI principle